### PR TITLE
fix: correct unix installer path expansion

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,3 +26,15 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+  install-script-regression:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Test install script path expansion
+      run: /bin/sh scripts/test/test_install_unix_path_expansion.sh

--- a/docs/assets/install/install-unix.sh
+++ b/docs/assets/install/install-unix.sh
@@ -75,7 +75,11 @@ expand_path() {
             printf '%s\n' "$HOME"
             ;;
         "~/"*)
-            printf '%s/%s\n' "$HOME" "${1#~/}"
+            # Avoid using "~" in parameter-expansion patterns because macOS /bin/sh
+            # can keep the literal "~/" and produce "$HOME/~/" style paths.
+            relative_path=${1#?}
+            relative_path=${relative_path#/}
+            printf '%s/%s\n' "$HOME" "$relative_path"
             ;;
         *)
             printf '%s\n' "$1"

--- a/scripts/test/README.md
+++ b/scripts/test/README.md
@@ -10,6 +10,7 @@
 
 ### 多平台测试脚本
 - `test_multiplatform_restart.sh` - 跨平台服务重启测试脚本（Linux/macOS）
+- `test_install_unix_path_expansion.sh` - Unix 一键安装脚本路径展开回归测试
 - `test_multiplatform_restart.bat` - 跨平台服务重启测试脚本（Windows）
 
 ### API测试脚本
@@ -28,6 +29,10 @@ chmod +x test_restart.sh
 # 多平台测试
 chmod +x test_multiplatform_restart.sh
 ./test_multiplatform_restart.sh
+
+# 安装脚本回归测试
+chmod +x test_install_unix_path_expansion.sh
+./test_install_unix_path_expansion.sh
 ```
 
 ### Windows
@@ -45,7 +50,8 @@ test_multiplatform_restart.bat
 1. 运行模式检测API (`/admin/service/mode`)
 2. 服务重启API (`/admin/service/restart`)
 3. 多平台兼容性验证
-4. 错误处理和回退机制
+4. Unix 安装脚本 `~` 路径展开回归验证
+5. 错误处理和回退机制
 
 ## 注意事项
 

--- a/scripts/test/test_install_unix_path_expansion.sh
+++ b/scripts/test/test_install_unix_path_expansion.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+TARGET_SCRIPT="$REPO_ROOT/docs/assets/install/install-unix.sh"
+
+TMP_DIR=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT INT HUP TERM
+
+EXTRACTED_FUNCTION="$TMP_DIR/expand_path.sh"
+
+awk '
+    /^expand_path\(\) \{/ { capture = 1 }
+    capture { print }
+    capture && /^}/ { exit }
+' "$TARGET_SCRIPT" >"$EXTRACTED_FUNCTION"
+
+if [ ! -s "$EXTRACTED_FUNCTION" ]; then
+    printf 'Failed to extract expand_path() from %s\n' "$TARGET_SCRIPT" >&2
+    exit 1
+fi
+
+run_expand() {
+    home_dir=$1
+    input_path=$2
+    HOME=$home_dir /bin/sh -c '. "$1"; expand_path "$2"' sh "$EXTRACTED_FUNCTION" "$input_path"
+}
+
+assert_eq() {
+    actual=$1
+    expected=$2
+    message=$3
+    if [ "$actual" != "$expected" ]; then
+        printf 'FAIL: %s\n' "$message" >&2
+        printf 'expected: %s\n' "$expected" >&2
+        printf 'actual:   %s\n' "$actual" >&2
+        exit 1
+    fi
+}
+
+assert_eq "$(run_expand "/tmp/fake-home" "~")" \
+    "/tmp/fake-home" \
+    'expands "~" to HOME'
+
+assert_eq "$(run_expand "/tmp/fake-home" "~/.ssh/id_rsa")" \
+    "/tmp/fake-home/.ssh/id_rsa" \
+    'expands "~/.ssh/id_rsa" without leaving a literal "~/" segment'
+
+assert_eq "$(run_expand "/tmp/fake home" "~/.ssh/id_rsa")" \
+    "/tmp/fake home/.ssh/id_rsa" \
+    'preserves spaces in HOME when expanding "~/" paths'
+
+assert_eq "$(run_expand "/tmp/fake-home" "/opt/keys/id_rsa")" \
+    "/opt/keys/id_rsa" \
+    'keeps absolute paths unchanged'
+
+assert_eq "$(run_expand "/tmp/fake-home" "keys/id_rsa")" \
+    "keys/id_rsa" \
+    'keeps relative paths unchanged'
+
+printf 'expand_path() regression tests passed.\n'


### PR DESCRIPTION
## Summary
- fix `~/.ssh/id_rsa` expansion in the Unix one-click installer under macOS `/bin/sh`
- add a regression test for `expand_path()` in `docs/assets/install/install-unix.sh`
- run the install-script regression check on both Ubuntu and macOS in CI

## Testing
- `/bin/sh scripts/test/test_install_unix_path_expansion.sh`
- `/bin/sh -n docs/assets/install/install-unix.sh`
- `git diff --check`